### PR TITLE
Return the actual found node

### DIFF
--- a/src/SRU/Record.php
+++ b/src/SRU/Record.php
@@ -57,7 +57,7 @@ class Record
         if(!$this->recordData) {
             $nodes = $this->xpath->query("./zs:recordData", $this->node);
             foreach($nodes as $node) {
-                $this->recordData = $node->firstChild;
+                $this->recordData = $node;
             }
         }
         if($raw && $this->packing() == "xml") {


### PR DESCRIPTION
The data function should be returning either an XML node or an XMLstring. 
The XML String part was broken as record data was being set to a DOMText node.