### PR TITLE
Lowercase composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "talis/SRUClient-php",
+    "name": "talis/sruclient-php",
     "description": "This is a php client library for SRU (http://www.loc.gov/standards/sru/)",
     "keywords": ["sru", "php", "client library"],
     "homepage": "https://github.com/talis/SRUclient-php",


### PR DESCRIPTION
This package currently causes
> Deprecation warning: require.talis/SRUClient-php is invalid, it should not contain uppercase characters. Please use talis/sruclient-php instead. Make sure you fix this as Composer 2.0 will error.

when running composer install.