### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,7 @@ workflows:
           matrix:
             parameters:
               php_version:
-                - 7.4
+                - '7.3'
+                - '7.4'
+                - '8.0'
+                - '8.3'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+
+jobs:
+  lint:
+    docker:
+      - image: cimg/php:7.4
+    steps:
+      - checkout
+      - run: composer install
+      - run: composer lint -- --report=full --report-junit=php_codesniffer-junit.xml
+      - store_test_results:
+          path: php_codesniffer-junit.xml
+      - store_artifacts:
+          path: php_codesniffer-junit.xml
+
+  test:
+    parameters:
+      php_version:
+        type: string
+    docker:
+      - image: cimg/php:<< parameters.php_version >>
+    steps:
+      - checkout
+      - run: composer install
+      - run: composer test -- --log-junit phpunit-junit.xml
+      - store_test_results:
+          path: phpunit-junit.xml
+      - store_artifacts:
+          path: phpunit-junit.xml
+
+workflows:
+  build_and_test:
+    jobs:
+      - lint
+      - test:
+          matrix:
+            parameters:
+              php_version:
+                - 7.4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 atlassian-ide-plugin.xml
 vendor/
+.phpunit.result.cache
 composer.phar
 composer.lock
 *-junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-
+.vscode/
 .idea/
 atlassian-ide-plugin.xml
 vendor/
 composer.phar
 composer.lock
+*-junit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-php:
-    - '5.5'
-    - '5.6'
-    - '7.0'
-    - '7.1'
-install: 
-    - composer install
-    - composer dumpautoload

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,16 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",
-        "phpunit/phpunit": "4.8.36",
+        "phpunit/phpunit": "^6.5.14",
         "pear/file_marc": "1.1.2"
     },
     "autoload":{
-        "psr-0": {
-            "SRU": "src"
+        "psr-4": {
+            "SRU\\": "src/SRU/"
         }
+    },
+    "scripts": {
+        "lint": "phpcs --standard=PSR2 src",
+        "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require":{
-        "php": ">=5.4.0",
+        "php": ">=7.3",
         "monolog/monolog": ">=1.5.0",
         "guzzle/guzzle":"~3.7"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",
-        "phpunit/phpunit": "^6.5.14",
+        "phpunit/phpunit": "^8.5.38",
         "pear/file_marc": "1.1.2"
     },
     "autoload":{

--- a/src/SRU/Client.php
+++ b/src/SRU/Client.php
@@ -98,7 +98,8 @@ class Client
      * Performs a searchRetrieve operation and returns a SearchRetrieveResponse object or a string is $raw is true
      *
      * @param string $query The CQL query string
-     * @param array $options The query options ('version', 'maximumRecords', 'startRecord', 'recordSchema', 'recordPacking')
+     * @param array $options The query options
+     *                       ('version', 'maximumRecords', 'startRecord', 'recordSchema', 'recordPacking')
      * @param bool $raw If true, returns the response as a string
      * @return SearchRetrieveResponse|string
      */

--- a/tests/unit/RecordTest.php
+++ b/tests/unit/RecordTest.php
@@ -24,7 +24,7 @@ class RecordTest extends TestCase
             );
             $rawData = $record->data(true);
             $this->assertTrue(is_string($rawData));
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '<srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:srw/schema/1/dc-schema http://www.loc.gov/standards/sru/resources/dc-schema.xsd">',
                 $rawData
             );
@@ -43,14 +43,14 @@ class RecordTest extends TestCase
             $this->assertEquals($i + 1, $record->position());
             $data = $record->data();
             $this->assertInstanceOf('\DOMText', $data);
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '<srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:srw/schema/1/dc-schema http://www.loc.gov/standards/sru/resources/dc-schema.xsd">',
                 $data->wholeText
             );
 
             $rawData = $record->data(true);
             $this->assertTrue(is_string($rawData));
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '<srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="info:srw/schema/1/dc-schema http://www.loc.gov/standards/sru/resources/dc-schema.xsd">',
                 $rawData
             );
@@ -77,7 +77,7 @@ class RecordTest extends TestCase
             $this->assertTrue($data->isDefaultNamespace('http://www.loc.gov/MARC21/slim'));
             $rawData = $record->data(true);
             $this->assertTrue(is_string($rawData));
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '<record xmlns="http://www.loc.gov/MARC21/slim">',
                 $rawData
             );
@@ -110,7 +110,7 @@ class RecordTest extends TestCase
         $this->assertFalse($data->isDefaultNamespace('http://www.loc.gov/MARC21/slim'));
         $rawData = $record->data(true);
         $this->assertTrue(is_string($rawData));
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<recordData><leader>00953nam  2200289   4500</leader>',
             $rawData
         );


### PR DESCRIPTION
- Add CircleCI config to run linting (php_codesniffer) and tests (PHPUnit)
  - Fix linting issue with docblock line length
- Correct version of phpunit/phpunit (tests were using namespaced TestCase which is available since 6.0)
- Change autoloading to PSR-4 (no change to how classes are used)
- Add Composer scripts